### PR TITLE
Implementation of LDAP email search functionality

### DIFF
--- a/src/job_defense_shield/base.py
+++ b/src/job_defense_shield/base.py
@@ -9,7 +9,7 @@ from .utils import send_email
 from .utils import SECONDS_PER_HOUR as sph
 from .utils import HOURS_PER_DAY as hpd
 from .efficiency import get_nodelist
-
+from .ldap import ldap_email_lookup
 
 class Alert:
 
@@ -81,6 +81,8 @@ class Alert:
             for user, email, usr in self.emails:
                 if user in self.external_emails:
                     user_email_address = self.external_emails[user]
+                if self.ldap_server:
+                    user_email_address = ldap_email_lookup(user, ldap_server=self.ldap_server, ldap_org=self.ldap_org, ldap_password=self.ldap_password)
                 else:
                     user_email_address = f"{user}{self.email_domain}"
                 send_email(email,
@@ -211,7 +213,7 @@ class Alert:
             if not vhist.empty:
                 last_sent_email_date = vhist["Email-Sent"].max()
         seconds_since_last_email = datetime.now().timestamp() - last_sent_email_date.timestamp()
-        seconds_threshold = self.days_between_emails * hpd * sph 
+        seconds_threshold = self.days_between_emails * hpd * sph
         return seconds_since_last_email >= seconds_threshold
 
     def get_emails_sent_count(self, user: str, violation: str) -> str:

--- a/src/job_defense_shield/ldap.py
+++ b/src/job_defense_shield/ldap.py
@@ -1,0 +1,25 @@
+import subprocess
+
+
+def ldap_email_lookup(user: str, ldap_server: str, ldap_org: str, ldap_password: str) -> str:
+
+    """
+    Function to take a username and perform an ldaps query to get the mail entry.
+    This is useful for institutions which do not use standardized email addresses.
+    """
+
+    cmd = f"ldapsearch -xLLL -H ldaps://{ldap_server} -b ou=People,o={ldap_org} -D cn=client,o={ldap_org} -w {ldap_password} '(uid={user})' mail"
+    output = subprocess.run(cmd,
+                            stdout=subprocess.PIPE,
+                            shell=True,
+                            timeout=5,
+                            text=True,
+                            check=True)
+    lines = output.stdout.split('\n')
+    email = ''
+    for line in lines:
+        if line.startswith("mail: "):
+            email = line.replace("mail:", "").strip()
+
+    return email
+

--- a/src/job_defense_shield/utils.py
+++ b/src/job_defense_shield/utils.py
@@ -138,7 +138,7 @@ def read_config_file(config_file: Optional[str],
     else:
         print("ERROR: Configuration file not found. Exiting ...")
         sys.exit()
- 
+
     # check for and/or create the violation logs directory
     if "violation-logs-path" not in cfg:
         print('ERROR: "violation-logs-path" must be specified in the configuration file.')
@@ -189,6 +189,13 @@ def read_config_file(config_file: Optional[str],
         cfg["smtp-password"] = smtp_password_from_env
     if "smtp-port" not in cfg:
         cfg["smtp-port"] = None
+    if "ldap-server" not in cfg:
+        cfg["ldap-server"] = None
+    if "ldap-password" not in cfg:
+        cfg["ldap-password"] = None
+    if "ldap-org" not in cfg:
+        cfg["ldap-org"] = None
+
 
     # system or global configuration settings
     sys_cfg = {"no_emails_to_users":   no_emails_to_users,
@@ -205,7 +212,11 @@ def read_config_file(config_file: Optional[str],
                "smtp_user":            cfg["smtp-user"],
                "smtp_password":        cfg["smtp-password"],
                "smtp_port":            cfg["smtp-port"],
-               "show_empty_reports":   cfg["show-empty-reports"]}
+               "show_empty_reports":   cfg["show-empty-reports"],
+               "ldap_server":          cfg["ldap-server"],
+               "ldap_org":             cfg["ldap-org"],
+               "ldap_password":        cfg["ldap-password"],
+        }
     return cfg, sys_cfg, head
 
 def display_alerts(cfg: dict) -> str:


### PR DESCRIPTION
Not every institution uses `username@institution.edu` as their email address structure. Frustratingly, we don't have a rigidly standardized format for email addresses, so we keep track of them for all users in our LDAP database. 

Instead of populating a massive list of "external emails" in our config.yaml file I've implemented the following:

- three new global config values for `ldap_server`, `ldap_org`, and `ldap_password`
- new function (`ldap_email_lookup` inside `ldap.py`) that takes a username and the three ldap parameters and returns the email address. This function follows the structure of the GreetingLDAP function (using subprocess instead of the ldap python module). 
- new option for setting the `user_email_address` in `base.py` that calls that function based on whether `ldap_server` is set

I'm not sure if this is the structure that you guys would like to use, so I understand if you want this function to be set somewhere else. 

Possible extensions include:

- modifying the `GreetingLDAP` function to use these ldap config variables
- better handling of cases when there is no `mail` attribute for a user (which isn't really possible in our case since this is required at account creation time)